### PR TITLE
Fix Travis CI issue with Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-    - "node"
+    - 17

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stderr-error-parser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stderr-error-parser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "stderr-error-parser",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Parse error stack from stderr of a Node.js process",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "stderr-error-parser",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Parse error stack from stderr of a Node.js process",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Changed Node.js version used in Travis config to 17 to fix the `The command "npm config set spin false" failed and exited with 1 during .` issue due to previous config.